### PR TITLE
Kill bashizm

### DIFF
--- a/configure
+++ b/configure
@@ -14197,7 +14197,7 @@ fi
           touch aclocal.m4 Makefile.in */Makefile.in configure config.h.in
 
 
- if test x$have_jpeg == xyes; then
+ if test x$have_jpeg = xyes; then
   HAVE_JPEG_TRUE=
   HAVE_JPEG_FALSE='#'
 else
@@ -14205,7 +14205,7 @@ else
   HAVE_JPEG_FALSE=
 fi
 
- if test x$have_png == xyes; then
+ if test x$have_png = xyes; then
   HAVE_PNG_TRUE=
   HAVE_PNG_FALSE='#'
 else

--- a/configure.ac
+++ b/configure.ac
@@ -367,8 +367,8 @@ AC_DEFUN([LS_UPDATE_TIMESTAMP], [
           ])
 LS_UPDATE_TIMESTAMP
 
-AM_CONDITIONAL([HAVE_JPEG], [test x$have_jpeg == xyes])
-AM_CONDITIONAL([HAVE_PNG], [test x$have_png == xyes])
+AM_CONDITIONAL([HAVE_JPEG], [test x$have_jpeg = xyes])
+AM_CONDITIONAL([HAVE_PNG], [test x$have_png = xyes])
 
 AC_CONFIG_FILES([Makefile
                  libsixel.pc


### PR DESCRIPTION
'=' operator for test(1) is not portable.
