### PR TITLE
Fix check for gdImageCreateFromPngPtr availability

### DIFF
--- a/configure
+++ b/configure
@@ -14064,9 +14064,9 @@ _ACEOF
 
 fi
 
-        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gdImageCreateFromBmpPtr in -lgd" >&5
-$as_echo_n "checking for gdImageCreateFromBmpPtr in -lgd... " >&6; }
-if ${ac_cv_lib_gd_gdImageCreateFromBmpPtr+:} false; then :
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gdImageCreateFromPngPtr in -lgd" >&5
+$as_echo_n "checking for gdImageCreateFromPngPtr in -lgd... " >&6; }
+if ${ac_cv_lib_gd_gdImageCreateFromPngPtr+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
@@ -14080,27 +14080,27 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #ifdef __cplusplus
 extern "C"
 #endif
-char gdImageCreateFromBmpPtr ();
+char gdImageCreateFromPngPtr ();
 int
 main ()
 {
-return gdImageCreateFromBmpPtr ();
+return gdImageCreateFromPngPtr ();
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_gd_gdImageCreateFromBmpPtr=yes
+  ac_cv_lib_gd_gdImageCreateFromPngPtr=yes
 else
-  ac_cv_lib_gd_gdImageCreateFromBmpPtr=no
+  ac_cv_lib_gd_gdImageCreateFromPngPtr=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_gd_gdImageCreateFromBmpPtr" >&5
-$as_echo "$ac_cv_lib_gd_gdImageCreateFromBmpPtr" >&6; }
-if test "x$ac_cv_lib_gd_gdImageCreateFromBmpPtr" = xyes; then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_gd_gdImageCreateFromPngPtr" >&5
+$as_echo "$ac_cv_lib_gd_gdImageCreateFromPngPtr" >&6; }
+if test "x$ac_cv_lib_gd_gdImageCreateFromPngPtr" = xyes; then :
   ac_fn_c_check_decl "$LINENO" "gdImageCreateFromPngPtr" "ac_cv_have_decl_gdImageCreateFromPngPtr" " #include <gd.h>
 "
 if test "x$ac_cv_have_decl_gdImageCreateFromPngPtr" = xyes; then :

--- a/configure.ac
+++ b/configure.ac
@@ -354,7 +354,7 @@ if test x$with_gd != xno; then
                      [gdImageCreateFromGifPtr],
                      [AC_CHECK_DECLS([gdImageCreateFromGifPtr],   [], [], [ #include <gd.h> ])])
         AC_CHECK_LIB([gd],
-                     [gdImageCreateFromBmpPtr],
+                     [gdImageCreateFromPngPtr],
                      [AC_CHECK_DECLS([gdImageCreateFromPngPtr],   [], [], [ #include <gd.h> ])])
         AC_CHECK_LIB([gd],
                      [gdImageCreateFromBmpPtr],


### PR DESCRIPTION
I found this while working on https://bugs.gentoo.org/show_bug.cgi?id=570068