### PR TITLE
fix wrong ref counting in sixel_decoder_decode

### DIFF
--- a/src/decoder.c
+++ b/src/decoder.c
@@ -328,7 +328,7 @@ sixel_decoder_decode(
 
 end:
     sixel_allocator_free(decoder->allocator, pixels);
-    sixel_decoder_ref(decoder);
+    sixel_decoder_unref(decoder);
 
     return status;
 }


### PR DESCRIPTION
sixel_decoder_decodeの中でdecoder->refが2つ増えるのを修正します。