### PR TITLE
Add size check

### DIFF
--- a/src/fromsixel.c
+++ b/src/fromsixel.c
@@ -290,7 +290,7 @@ image_buffer_resize(
 
     size = (size_t)(width * height);
     alt_buffer = (unsigned char *)sixel_allocator_malloc(allocator, size);
-    if (alt_buffer == NULL) {
+    if (alt_buffer == NULL || size == 0) {
         /* free source image */
         sixel_allocator_free(allocator, image->data);
         image->data = NULL;


### PR DESCRIPTION
#81 seems that caused by size_t overflow.
When invoke img2sixel with POC2, two variables width and height contain 67108864,
so size = (size_t)(width * height), as a result , size = 0.
