### PR TITLE
assign default error message

### DIFF
--- a/src/stb_image.h
+++ b/src/stb_image.h
@@ -845,6 +845,8 @@ static const char *stbi__g_failure_reason;
 
 STBIDEF const char *stbi_failure_reason(void)
 {
+   if (stbi__g_failure_reason == NULL)
+      stbi__g_failure_reason = "unknwon error, refer error message before assignment";
    return stbi__g_failure_reason;
 }
 


### PR DESCRIPTION
#79 
This is caused by NULL pointer reference.
