### PR TITLE
prevent to access heap overflow

### DIFF
--- a/src/fromsixel.c
+++ b/src/fromsixel.c
@@ -884,7 +884,10 @@ sixel_decode_raw(
     }
 
     *ncolors = image.ncolors + 1;
-    *palette = (unsigned char *)sixel_allocator_malloc(allocator, (size_t)(*ncolors * 3));
+    int alloc_size = *ncolors;
+    if (alloc_size < 256) // memory access range should be 0 <= 255 (in write_png_to_file)
+        alloc_size = 256;
+    *palette = (unsigned char *)sixel_allocator_malloc(allocator, (size_t)(alloc_size * 3));
     if (palette == NULL) {
         sixel_allocator_free(allocator, image.data);
         sixel_helper_set_additional_message(


### PR DESCRIPTION
#82
This problem caused by the following line:
https://github.com/saitoha/libsixel/blob/master/src/writer.c#L160
```
        for (i = 0; i < width * height; ++i, ++src) {
            *dst++ = *(palette + *src * 3 + 0);
            *dst++ = *(palette + *src * 3 + 1);
            *dst++ = *(palette + *src * 3 + 2);
        }
```
https://bugzilla.redhat.com/show_bug.cgi?id=1649201
The above POC causes to store 255 value on *src, so always allocation 256*3 size of memory to *palette prevent heap overflow.