### PR TITLE
Fix decoding of high-color sixel images when the palette changes.

### DIFF
--- a/src/decoder.c
+++ b/src/decoder.c
@@ -324,7 +324,7 @@ sixel_decoder_decode(
     }
 
     status = sixel_helper_write_image_file(indexed_pixels, sx, sy, palette,
-                                           SIXEL_PIXELFORMAT_PAL8,
+                                           SIXEL_PIXELFORMAT_RGB888,
                                            decoder->output,
                                            SIXEL_FORMAT_PNG,
                                            decoder->allocator);


### PR DESCRIPTION
This request fixes an issue where sixel2img fails to handle high-color sixel where the palette changes. This is the cause of issue #61