### PR TITLE
export `sixel_allocator_new` to dll

### DIFF
--- a/include/sixel.h.in
+++ b/include/sixel.h.in
@@ -506,7 +506,7 @@ extern "C" {
 #endif
 
 /* create allocator object */
-SIXELSTATUS
+SIXELAPI SIXELSTATUS
 sixel_allocator_new(
     sixel_allocator_t   /* out */ **ppallocator,  /* allocator object to be created */
     sixel_malloc_t      /* in */  fn_malloc,      /* custom malloc() function */


### PR DESCRIPTION
I believe this was a mistake so I add the `SIXELAPI` macro.

This solves the issue in https://github.com/johnnychen94/Sixel.jl/issues/5