### PR TITLE
Replace have with command in bash completion

### DIFF
--- a/converters/shell-completion/bash/img2sixel
+++ b/converters/shell-completion/bash/img2sixel
@@ -1,6 +1,6 @@
 # bash completion for img2sixel
 
-have img2sixel &&
+command -v img2sixel &>/dev/null &&
 _img2sixel()
 {
     local cur prev


### PR DESCRIPTION
`have` is not a standard unix/bash command. 
Trying to tab complete with image2sixel results in the following printed to stderr:

```
bash: have: command not found
```