### PR TITLE
Fix segfault caused by uninitialized dither

### DIFF
--- a/include/sixel.h.in
+++ b/include/sixel.h.in
@@ -1008,6 +1008,12 @@ typedef SIXELSTATUS (* sixel_load_image_function)(
     sixel_frame_t /* in */     *frame,
     void          /* in/out */ *context);
 
+/* Note: this function returns SIXEL_OK without calling FN_LOAD when the file
+   content is empty or 1-byte LF.  This implies an assumption that CONTEXT is
+   initialized to be the default value for the empty file before calling this
+   function.  If it is not the case, the caller needs to properly detect it and
+   handle this, or otherwise, CONTEXT can be used uninitialized in subsequent
+   codes. */
 SIXELAPI SIXELSTATUS
 sixel_helper_load_image_file(
     char const                /* in */     *filename,     /* source file name */

--- a/src/encoder.c
+++ b/src/encoder.c
@@ -462,6 +462,13 @@ sixel_prepare_specified_palette(
         return status;
     }
 
+    if (!callback_context.dither) {
+        sixel_helper_set_additional_message(
+            "sixel_prepare_specified_palette() failed.\n"
+            "reason: mapfile is empty.");
+        return SIXEL_BAD_INPUT;
+    }
+
     *dither = callback_context.dither;
 
     return status;


### PR DESCRIPTION
This patch was originally suggested in Issue #193 by @momo-trip. I prepared the commit with the author being credited to @momo-trip. I removed the unnecessary string copy and added a note on the function `sixel_helper_load_image_file` in a code comment, and @saitoha suggested the proper return value `SIXEL_BAD_INPUT`.

Resolves #193