### PR TITLE
[RFC] libsixel-specific error diffusion (dithering) to improve sixel compression

### DIFF
--- a/converters/img2sixel.1
+++ b/converters/img2sixel.1
@@ -97,6 +97,8 @@ burkes   -> Burkes' method
 a_dither -> positionally stable arithmetic dither
 .br
 x_dither -> positionally stable arithmetic xor based dither
+.br
+lso1     -> libsixel's original method
 .TP 5
 .B \-f \fIFINDTYPE\fP, \-\-find\-largest=\fIFINDTYPE\fP
 choose method for finding the largest dimension of median

--- a/converters/img2sixel.c
+++ b/converters/img2sixel.c
@@ -172,6 +172,7 @@ void show_help(void)
             "                                         arithmetic dither\n"
             "                             x_dither -> positionally stable\n"
             "                                         arithmetic xor based dither\n"
+            "                             lso1     -> libsixel's original method\n"
             "-f FINDTYPE, --find-largest=FINDTYPE\n"
             "                           choose method for finding the largest\n"
             "                           dimension of median cut boxes for\n"

--- a/include/sixel.h.in
+++ b/include/sixel.h.in
@@ -101,6 +101,7 @@ typedef int SIXELSTATUS;
 #define SIXEL_DIFFUSE_BURKES      0x6  /* diffuse with Burkes' method */
 #define SIXEL_DIFFUSE_A_DITHER    0x7  /* positionally stable arithmetic dither */
 #define SIXEL_DIFFUSE_X_DITHER    0x8  /* positionally stable arithmetic xor based dither */
+#define SIXEL_DIFFUSE_LSO1        0x9  /* diffuse with libsixel's original method */
 
 /* quality modes */
 #define SIXEL_QUALITY_AUTO        0x0  /* choose quality mode automatically */
@@ -412,7 +413,8 @@ enum methodForDiffuse {
     DIFFUSE_STUCKI   = 5, /* diffuse with Stucki's method */
     DIFFUSE_BURKES   = 6, /* diffuse with Burkes' method */
     DIFFUSE_A_DITHER = 7, /* positionally stable arithmetic dither */
-    DIFFUSE_X_DITHER = 8  /* positionally stable arithmetic xor based dither */
+    DIFFUSE_X_DITHER = 8, /* positionally stable arithmetic xor based dither */
+    DIFFUSE_LSO1     = 9  /* libsixel original diffusion method */
 };
 
 /* quality modes */

--- a/python/libsixel/__init__.py
+++ b/python/libsixel/__init__.py
@@ -89,6 +89,7 @@ SIXEL_DIFFUSE_STUCKI    = 0x5  # diffuse with Stucki's method
 SIXEL_DIFFUSE_BURKES    = 0x6  # diffuse with Burkes' method
 SIXEL_DIFFUSE_A_DITHER  = 0x7  # positionally stable arithmetic dither
 SIXEL_DIFFUSE_X_DITHER  = 0x8  # positionally stable arithmetic xor based dither
+SIXEL_DIFFUSE_LSO1      = 0x9  # diffuse with libsixel original method
 
 # quality modes
 SIXEL_QUALITY_AUTO      = 0x0  # choose quality mode automatically
@@ -213,6 +214,7 @@ SIXEL_OPTFLAG_DIFFUSION        = 'd'  # -d DIFFUSIONTYPE, --diffusion=DIFFUSIONT
                                       #                        arithmetic dither
                                       #            x_dither -> positionally stable
                                       #                        arithmetic xor based dither
+                                      #            lso1     -> libsixel's original method
 
 SIXEL_OPTFLAG_FIND_LARGEST     = 'f'  # -f FINDTYPE, --find-largest=FINDTYPE:
                                       #         choose method for finding the largest

--- a/src/encoder.c
+++ b/src/encoder.c
@@ -1392,6 +1392,8 @@ sixel_encoder_setopt(
             encoder->method_for_diffuse = SIXEL_DIFFUSE_A_DITHER;
         } else if (strcmp(value, "x_dither") == 0) {
             encoder->method_for_diffuse = SIXEL_DIFFUSE_X_DITHER;
+        } else if (strcmp(value, "lso1") == 0) {
+            encoder->method_for_diffuse = SIXEL_DIFFUSE_LSO1;
         } else {
             sixel_helper_set_additional_message(
                 "specified diffusion method is not supported.");


### PR DESCRIPTION
I propose a new dithering option `-d lso1`.
It gently steers error diffusion so that grainy noise turns into faint horizontal bands, improving SIXEL RLE compressibility at a slight perceptual cost.
Effects are modest compared to `-E size`; expected size reductions are only a few percent.

<img width="1512" height="915" alt="image" src="https://github.com/user-attachments/assets/79acaa8c-2508-4fc2-a3b6-cb6eeef2a483" />

<img width="400" height="240" alt="image" src="https://github.com/user-attachments/assets/2385d2e8-49bb-4d5c-a584-c2c66731d380" />

<img width="400" height="240" alt="image" src="https://github.com/user-attachments/assets/54f88267-81de-4c46-aa3f-19710afee7b3" />