### PR TITLE
Fix link to schrmh/pdfgrepSIXEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1565,7 +1565,7 @@ We are greatly inspired by the quality of ImageMagick and added some resampling 
 
 - [ismail-yilmaz/upp-components/CtrlLib/Terminal/](https://github.com/ismail-yilmaz/upp-components/tree/master/CtrlLib/Terminal)
 
-- [schrmh/pdfgrepSIXEL](schrmh/pdfgrepSIXEL)
+- [schrmh/pdfgrepSIXEL](https://github.com/schrmh/pdfgrepSIXEL)
 
 - [ar90n/teimpy](https://github.com/ar90n/teimpy)
 


### PR DESCRIPTION
Missing https://github.com/ in front of schrmh/pdfgrepSIXEL and thus it leads to a 404.

Btw. thanks for looking out for projects using SIXEL back then and listening those in the README. This alongside the patches you wrote are probably the reason why SIXEL is so popular again.