### PR TITLE
Fix bugs in python sixel_encoder_encode_bytes

### DIFF
--- a/python/libsixel/__init__.py
+++ b/python/libsixel/__init__.py
@@ -657,22 +657,17 @@ def sixel_encoder_encode_bytes(encoder, buf, width, height, pixelformat, palette
         raise ValueError("invalid pixelformat value : %d" % pixelformat)
 
     if len(buf) < width * height * depth:
-        raise ValueError("buf.len is too short : %d < %d * %d * %d" % (buf.len, width, height, depth))
-
-    if not hasattr(buf, "readonly") or buf.readonly:
-        cbuf = c_void_p.from_buffer_copy(buf)
-    else:
-        cbuf = c_void_p.from_buffer(buf)
+        raise ValueError("buf.len is too short : %d < %d * %d * %d" % (len(buf), width, height, depth))
 
     if palette:
         cpalettelen = len(palette)
         cpalette = (c_byte * cpalettelen)(*palette)
     else:
-        cpalettelen = None
+        cpalettelen = 0
         cpalette = None
 
     _sixel.sixel_encoder_encode_bytes.restype = c_int
-    _sixel.sixel_encoder_encode.argtypes = [c_void_p, c_void_p, c_int, c_int, c_int, c_void_p, c_int]
+    _sixel.sixel_encoder_encode_bytes.argtypes = [c_void_p, c_void_p, c_int, c_int, c_int, c_void_p, c_int]
 
     status = _sixel.sixel_encoder_encode_bytes(encoder, buf, width, height, pixelformat, cpalette, cpalettelen)
     if SIXEL_FAILED(status):


### PR DESCRIPTION
Data length incorrect error message uses buf.len, but this does not exist, correct function is len(buf), as used on previous line.

Argument type check via ctype was setting args to the wrong function from libsixel.

The palette length when no palette is specified was passed as None, it should be 0.  This error is detected after argument type checking is fixed.

cbuf is created from buf argument, but it's not done correctly.  What it does is make a pointer the address made from the first 32/64 bits of data in the buffer.  I.e., it makes a pointing using the image pixels as if they were a pointer.  That makes a random pointer to nowhere.

But cbuf is never used, so this code can just be deleted.  ctypes will convert a bytes() object or various other things into the correct type without help.